### PR TITLE
Feat: Static Typing

### DIFF
--- a/addons/netfox_sharp/autoloads/NetfoxSharp.cs
+++ b/addons/netfox_sharp/autoloads/NetfoxSharp.cs
@@ -20,7 +20,6 @@ public partial class NetfoxSharp : Node
 
     public override void _EnterTree()
     {
-        // TODO: Test to see if we need to AddChild() to get signals working.
         NetworkTime = new(GetNode("/root/NetworkTime"));
         NetworkTimeSynchronizer = new(GetNode("/root/NetworkTimeSynchronizer"));
         NetworkRollback = new(GetNode("/root/NetworkRollback"));

--- a/addons/netfox_sharp/autoloads/NetworkEvents.cs
+++ b/addons/netfox_sharp/autoloads/NetworkEvents.cs
@@ -28,7 +28,7 @@ public partial class NetworkEvents : Node
     /// <para>Events are only emitted when it's enabled. Disabling this can free up some
     /// performance, as when enabled, the multiplayer API and the host are
     /// continuously checked for changes.</para></summary>
-    public bool Enabled
+    public static bool Enabled
     {
         get { return (bool)_networkEventsGd.Get(PropertyNameGd.Enabled); }
         set { _networkEventsGd.Set(PropertyNameGd.Enabled, value); }
@@ -36,7 +36,7 @@ public partial class NetworkEvents : Node
     #endregion
 
     /// <summary>Internal reference of the NetworkEvents GDScript autoload.</summary>
-    GodotObject _networkEventsGd;
+    static GodotObject _networkEventsGd;
 
     /// <summary>Internal constructor used by <see cref="NetfoxSharp"/>. Should not be used elsewhere.</summary>
     /// <param name="networkTimeGd">The NetworkEvents GDScript autoload.</param>
@@ -87,7 +87,7 @@ public partial class NetworkEvents : Node
     #region Methods
     /// <summary>Check if we're running as server.</summary>
     /// <returns>Whether this instance is a server</returns>
-    public bool IsServer() { return (bool)_networkEventsGd.Call(MethodNameGd.IsServer); }
+    public static bool IsServer() { return (bool)_networkEventsGd.Call(MethodNameGd.IsServer); }
     #endregion
 
     #region StringName Constants

--- a/addons/netfox_sharp/autoloads/NetworkRollback.cs
+++ b/addons/netfox_sharp/autoloads/NetworkRollback.cs
@@ -13,52 +13,52 @@ public partial class NetworkRollback : Node
 {
     #region Public Variables
     /// <summary>Whether rollbacks are enabled.</summary>
-    public bool Enabled
+    public static bool Enabled
     {
         get { return (bool)_networkRollbackGd.Get(PropertyNameGd.Enabled); }
         set { _networkRollbackGd.Set(PropertyNameGd.Enabled, value); }
     }
     /// <summary><para>Whether diff states are enabled.</para>
     /// <para>Diff states send only the state properties that have changed.</para></summary>
-    public bool EnableDiffStates
+    public static bool EnableDiffStates
     {
         get { return (bool)_networkRollbackGd.Get(PropertyNameGd.EnableDiffStates); }
         set { _networkRollbackGd.Set(PropertyNameGd.EnableDiffStates, value); }
     }
     /// <summary><para>How many ticks to store as history.</para>
     /// <para>Rollback won't go further than this limit, regardless of inputs received.</para></summary>
-    public long HistoryLimit { get { return (long)_networkRollbackGd.Get(PropertyNameGd.HistoryLimit); } }
+    public static long HistoryLimit { get { return (long)_networkRollbackGd.Get(PropertyNameGd.HistoryLimit); } }
     /// <summary><para>The earliest tick that history is retained for.</para>
     /// <para>Determined by <see cref="HistoryLimit"/>.</para></summary>
-    public long HistoryStart { get { return (long)_networkRollbackGd.Get(PropertyNameGd.HistoryStart); } }
+    public static long HistoryStart { get { return (long)_networkRollbackGd.Get(PropertyNameGd.HistoryStart); } }
     /// <summary><para>Offset into the past for display.</para>
     /// <para>After the rollback, we have the option to not display the absolute latest
     /// state of the game, but let's say the state two frames ago ( offset = 2 ).
     /// This can help with hiding latency, by giving more time for an up-to-date
     /// state to arrive before we try to display it.</para></summary>
-    public long DisplayOffset { get { return (long)_networkRollbackGd.Get(PropertyNameGd.DisplayOffset); } }
+    public static long DisplayOffset { get { return (long)_networkRollbackGd.Get(PropertyNameGd.DisplayOffset); } }
     /// <summary><para>The currently displayed tick.</para>
     /// <para>This is the current tick as returned by <see cref="NetworkTime.tick"/>, minus
     /// the <see cref="DisplayOffset"/>. By configuring the <see cref="DisplayOffset"/>, a
     /// past tick may be displayed to the player, so that updates from the server
     /// have slightly more time to arrive, masking latency.</para></summary>
-    public long DisplayTick { get { return (long)_networkRollbackGd.Get(PropertyNameGd.DisplayTick); } }
+    public static long DisplayTick { get { return (long)_networkRollbackGd.Get(PropertyNameGd.DisplayTick); } }
     /// <summary><para>Offset into the future to submit inputs, in ticks.</para>
     /// <para>By submitting inputs into the future, they don't happen instantly, but with
     /// some delay. This can help hiding latency - even if input takes some time to
     /// arrive, it will still be up to date, as it was timestamped into the future.
     /// This only works if the input delay is greater than the network latency.</para></summary>
-    public long InputDelay { get { return (long)_networkRollbackGd.Get(PropertyNameGd.InputDelay); } }
+    public static long InputDelay { get { return (long)_networkRollbackGd.Get(PropertyNameGd.InputDelay); } }
     /// <summary><para>How many previous input frames to send along with the current one.</para>
     /// <para>With UDP - packets may be lost, arrive late or out of order.
     /// To mitigate this, we send the current and previous n ticks of input data.</para></summary>
-    public long InputRedundancy { get { return (long)_networkRollbackGd.Get(PropertyNameGd.InputRedundancy); } }
+    public static long InputRedundancy { get { return (long)_networkRollbackGd.Get(PropertyNameGd.InputRedundancy); } }
     /// <summary>The current tick.</summary>
-    public long Tick { get { return (long)_networkRollbackGd.Get(PropertyNameGd.Tick); } }
+    public static long Tick { get { return (long)_networkRollbackGd.Get(PropertyNameGd.Tick); } }
     #endregion
 
     /// <summary>Internal reference of the NetworkRollback GDScript autoload.</summary>
-    GodotObject _networkRollbackGd;
+    static GodotObject _networkRollbackGd;
 
     /// <summary>Internal constructor used by <see cref="NetfoxSharp"/>. Should not be used elsewhere.</summary>
     /// <param name="networkTimeGd">The NetworkRollback GDScript autoload.</param>
@@ -111,30 +111,30 @@ public partial class NetworkRollback : Node
     /// <summary><para>Submit the resimulation start tick for the current loop.</para>
     /// <para>This is used to determine the resimulation range during each loop.</para></summary>
     /// <param name="tick">The tick to resimulate from, at least.</param>
-    public void NotifyResimulationStart(long tick) { _networkRollbackGd.Call(MethodNameGd.NotifyResimulationStart, tick); }
+    public static void NotifyResimulationStart(long tick) { _networkRollbackGd.Call(MethodNameGd.NotifyResimulationStart, tick); }
     /// <summary><para>Submit node for simulation.</para>
     /// <para>This is used mostly internally by <see cref="RollbackSynchronizer"/>. The idea is to 
     /// submit each affected node while preparing the tick, and then run only the
     /// nodes that need to be resimulated.</para></summary>
     /// <param name="node"></param>
-    public void NotifySimulated(Node node) { _networkRollbackGd.Call(MethodNameGd.NotifySimulated, node); }
+    public static void NotifySimulated(Node node) { _networkRollbackGd.Call(MethodNameGd.NotifySimulated, node); }
     /// <summary><para>Check if node was submitted for simulation.</para>
     /// <para>This is used mostly internally by <see cref="RollbackSynchronizer"/>. The idea is to 
     /// submit each affected node while preparing the tick, and then use
     /// <see cref="IsSimulated(Node)"/> to run only the nodes that need to be resimulated.</para></summary>
     /// <param name="node">The node you want to check is being simulated</param>
     /// <returns>Whether the node is being simulated.</returns>
-    public bool IsSimulated(Node node) { return (bool)_networkRollbackGd.Call(MethodNameGd.IsSimulated, node); }
+    public static bool IsSimulated(Node node) { return (bool)_networkRollbackGd.Call(MethodNameGd.IsSimulated, node); }
     /// <summary>Check if a network rollback is currently active.</summary>
     /// <returns>Whether the network rollback is currently active.</returns>
-    public bool IsRollback() { return (bool)_networkRollbackGd.Call(MethodNameGd.IsRollback); }
+    public static bool IsRollback() { return (bool)_networkRollbackGd.Call(MethodNameGd.IsRollback); }
     /// <summary><para>Checks if a given object is rollback-aware, IE has a
     /// method named _rollback_tick implemented.</para>
     /// <para>This is used by <see cref="RollbackSynchronizer"/> to see if it should simulate the
     /// given object during rollback.</para></summary>
     /// <param name="what">The object to be checked.</param>
     /// <returns>Whether the object has a method named _rollback_tick</returns>
-    public bool IsRollbackAware(GodotObject what) { return (bool)_networkRollbackGd.Call(MethodNameGd.IsRollbackAware, what); }
+    public static bool IsRollbackAware(GodotObject what) { return (bool)_networkRollbackGd.Call(MethodNameGd.IsRollbackAware, what); }
     /// <summary><para>Calls the _rollback_tick method on the target, running its
     /// simulation for the given rollback tick.</para>
     /// <para>This is used by <see cref="RollbackSynchronizer"/> to resimulate ticks during rollback.
@@ -146,7 +146,7 @@ public partial class NetworkRollback : Node
     /// <param name="delta">The time delta.</param>
     /// <param name="tick">The simulated tick.</param>
     /// <param name="isFresh">Whether this is the first time this tick is being processed.</param>
-    public void ProcessRollback(GodotObject target, double delta, long tick, bool isFresh) { _networkRollbackGd.Call(MethodNameGd.ProcessRollback, target, delta, tick, isFresh); }
+    public static void ProcessRollback(GodotObject target, double delta, long tick, bool isFresh) { _networkRollbackGd.Call(MethodNameGd.ProcessRollback, target, delta, tick, isFresh); }
     /// <summary><para>Marks the target object as mutated.</para>
     /// <para>Mutated objects will be re-recorded for the specified tick, and resimulated
     /// from the given tick onwards.</para>
@@ -156,17 +156,17 @@ public partial class NetworkRollback : Node
     /// <para><b>NOTE:</b> Registering a mutation into the past will yield a warning.</para></summary>
     /// <param name="target">The target mutatable object.</param>
     /// <param name="tick">The tick to mutate from. Typically <see cref="Tick"/>.</param>
-    public void Mutate(GodotObject target, long tick) { _networkRollbackGd.Call(MethodNameGd.Mutate, target, tick); }
+    public static void Mutate(GodotObject target, long tick) { _networkRollbackGd.Call(MethodNameGd.Mutate, target, tick); }
     /// <summary><para>Check whether the target object was mutated in or after the given tick via
     /// <see cref="Mutate(GodotObject, long)"/>.</para></summary>
     /// <param name="target">The target object to check.</param>
     /// <param name="tick">The tick to check mutations from.</param>
-    public void IsMutated(GodotObject target, long tick) { _networkRollbackGd.Call(MethodNameGd.IsMutated, target, tick); }
+    public static void IsMutated(GodotObject target, long tick) { _networkRollbackGd.Call(MethodNameGd.IsMutated, target, tick); }
     /// <summary>Check whether the target object was mutated specifically in the given tick
     /// via <see cref="Mutate(GodotObject, long)"/>.</summary>
     /// <param name="target">The target object to check.</param>
     /// <param name="tick">The tick to check mutations from.</param>
-    public void IsJustMutated(GodotObject target, long tick) { _networkRollbackGd.Call(MethodNameGd.IsJustMutated, target, tick); }
+    public static void IsJustMutated(GodotObject target, long tick) { _networkRollbackGd.Call(MethodNameGd.IsJustMutated, target, tick); }
     #endregion
 
     #region StringName Constants

--- a/addons/netfox_sharp/autoloads/NetworkTime.cs
+++ b/addons/netfox_sharp/autoloads/NetworkTime.cs
@@ -15,18 +15,18 @@ public partial class NetworkTime : Node
 {
     #region Public Variables
     /// <summary>Number of ticks per second.</summary>
-    public long TickRate { get { return (long)_networkTimeGd.Get(PropertyNameGd.TickRate); } }
+    public static long TickRate { get { return (long)_networkTimeGd.Get(PropertyNameGd.TickRate); } }
     /// <summary><para>Whether to sync the network ticks to physics updates.</para>
     /// <para>When set to true, tickrate will be the same as the physics ticks per second, 
     /// and the network tick loop will be run inside the physics update process.</para></summary>
-    public bool SyncToPhysics { get { return (bool)_networkTimeGd.Get(PropertyNameGd.SyncToPhysics); } }
+    public static bool SyncToPhysics { get { return (bool)_networkTimeGd.Get(PropertyNameGd.SyncToPhysics); } }
     /// <summary><para>Maximum number of ticks to simulate per frame.</para>
     /// <para>If the game itself runs slower than the configured tickrate, multiple ticks
     /// will be run in a single go. However, to avoid an endless feedback loop of
     /// running too many ticks in a frame, which makes the game even slower, which
     /// results in even more ticks and so on, this setting is an upper limit on how
     /// many ticks can be simulated in a single go.</para></summary>summary>
-    public long MaxTicksPerFrame { get { return (long)_networkTimeGd.Get(PropertyNameGd.MaxTicksPerFrame); } }
+    public static long MaxTicksPerFrame { get { return (long)_networkTimeGd.Get(PropertyNameGd.MaxTicksPerFrame); } }
     /// <summary><para>Current network time in seconds.</para>
     /// <para>Time is measured from the start of NetworkTime, in practice this is often the
     /// time from the server's start.</para>
@@ -34,7 +34,7 @@ public partial class NetworkTime : Node
     /// <para><b>NOTE:</b> Time is continuously synced with the server. If the difference 
     /// between local and server time is above a certain threshold, this value will
     /// be adjusted.</para></summary>
-    public double Time { get { return (double)_networkTimeGd.Get(PropertyNameGd.Time); } }
+    public static double Time { get { return (double)_networkTimeGd.Get(PropertyNameGd.Time); } }
     /// <summary><para>Current network time in ticks.</para>
     /// <para>Ticks are measured from the start of NetworkTime, in practice this is often the
     /// time from the server's start.</para>
@@ -42,7 +42,7 @@ public partial class NetworkTime : Node
     /// <para><b>NOTE:</b> Time is continuously synced with the server. If the difference 
     /// between local and server time is above a certain threshold, this value will
     /// be adjusted.</para></summary>
-    public long Tick { get { return (long)_networkTimeGd.Get(PropertyNameGd.Tick); } }
+    public static long Tick { get { return (long)_networkTimeGd.Get(PropertyNameGd.Tick); } }
     /// <summary><para>Threshold before recalibrating <see cref="Tick"/> and <see cref="Time"/>.</para>
     /// <para>Time is continuously synced to the server. In case the time difference is 
     /// excessive between local and the server, both <see cref="Tick"/> and
@@ -51,26 +51,26 @@ public partial class NetworkTime : Node
     /// recalibration.</para>
     /// <para><b>NOTE:</b> Deprecated: Use <see cref="NetworkTimeSynchronizer.PanicThreshold"/> instead.</para></summary>
     [Obsolete]
-    public float RecalibrateThreshold { get { return (float)_networkTimeGd.Get(PropertyNameGd.RecalibrateThreshold); } }
+    public static float RecalibrateThreshold { get { return (float)_networkTimeGd.Get(PropertyNameGd.RecalibrateThreshold); } }
     /// <summary><para>Seconds required to pass before considering the game stalled.</para>
     /// <para>If the game becomes unresponsive for some time - e.g. it becomes minimized,
     /// unfocused, or freezes -, the game time needs to be readjusted. These stalls
     /// are detected by checking how much time passes between frames. If it's more
     /// than this threshold, it's considered a stall, and will be compensated
     /// against.</para></summary>
-    public float StallThreshold { get { return (float)_networkTimeGd.Get(PropertyNameGd.StallThreshold); } }
+    public static float StallThreshold { get { return (float)_networkTimeGd.Get(PropertyNameGd.StallThreshold); } }
     /// <summary><para>Estimated roundtrip time (ping) to server.</para>
     /// <para>This value is updated regularly, during server time sync. Latency can be 
     /// estimated as half of the roundtrip time. Returns the same as 
     /// <see cref="NetworkTimeSynchronizer.Rtt"/>.</para>
     /// <para><b>NOTE:</b> Will always be 0 on the server.</para></summary>
-    public double RemoteRtt { get { return (double)_networkTimeGd.Get(PropertyNameGd.RemoteRtt); } }
+    public static double RemoteRtt { get { return (double)_networkTimeGd.Get(PropertyNameGd.RemoteRtt); } }
     /// <summary><para>Amount of time a single tick takes, in seconds.</para>
     /// <para>This is the inverse of tickrate.</para></summary>
-    public double TickTime { get { return (double)_networkTimeGd.Get(PropertyNameGd.TickTime); } }
+    public static double TickTime { get { return (double)_networkTimeGd.Get(PropertyNameGd.TickTime); } }
     /// <summary><para>Progress towards the next tick from 0 - 1, where 0 is the start
     /// of the current tick and 1 is the start of the next tick.</para></summary>
-    public double TickFactor { get { return (double)_networkTimeGd.Get(PropertyNameGd.TickFactor); } }
+    public static double TickFactor { get { return (double)_networkTimeGd.Get(PropertyNameGd.TickFactor); } }
     /// <summary><para>Multiplier to get from physics process speeds to tick speeds.</para>
     /// <para>Some methods, like CharacterBody's move_and_slide take velocity in units/sec
     /// and figure out the time delta on their own. However, they are not aware of 
@@ -83,16 +83,16 @@ public partial class NetworkTime : Node
     /// persistent variable ( e.g. CharacterBody's velocity ).</para>
     /// <para><b>NOTE:</b> This works correctly both in regular and in physics frames, but may
     /// yield different values.</para></summary>
-    public double PhysicsFactor { get { return (double)_networkTimeGd.Get(PropertyNameGd.PhysicsFactor); } }
+    public static double PhysicsFactor { get { return (double)_networkTimeGd.Get(PropertyNameGd.PhysicsFactor); } }
     /// <summary><para>The maximum clock stretch factor allowed.</para>
     /// <para>For more context on clock stretch, see [member clock_stretch_factor]. The 
     /// minimum allowed clock stretch factor is derived as 1.0 / clock_stretch_max. 
     /// Setting this to larger values will allow for quicker clock adjustment at the 
     /// cost of bigger deviations in game speed.</para></summary>
-    public double ClockStretchMax { get { return (double)_networkTimeGd.Get(PropertyNameGd.ClockStretchMax); } }
+    public static double ClockStretchMax { get { return (double)_networkTimeGd.Get(PropertyNameGd.ClockStretchMax); } }
     /// <summary><para>Suppress warning when calling <see cref="Start"/> with an <see cref="OfflineMultiplayerPeer"/>
     /// active.</para></summary>
-    public bool SuppressOfflinePeerWarning { get { return (bool)_networkTimeGd.Get(PropertyNameGd.ClockStretchMax); } }
+    public static bool SuppressOfflinePeerWarning { get { return (bool)_networkTimeGd.Get(PropertyNameGd.ClockStretchMax); } }
     /// <summary><para>The currently used clock stretch factor.</para>
     /// <para>As the game progresses, the simulation clock may be ahead of, or behind the
     /// host's remote clock. To compensate, whenever the simulation clock is ahead of
@@ -103,24 +103,24 @@ public partial class NetworkTime : Node
     /// indicate speeding up, under 1.0 indicate slowing down.</para>
     /// <para>See <see cref="ClockStretchMax"/> for more clock stretch bounds.</para>
     /// <para>See <see cref="ClockStretchFactor"/> for more on the simulation clock.</para></summary>
-    public double ClockStretchFactor { get { return (double)_networkTimeGd.Get(PropertyNameGd.ClockStretchFactor); } }
+    public static double ClockStretchFactor { get { return (double)_networkTimeGd.Get(PropertyNameGd.ClockStretchFactor); } }
     /// <summary><para>The current estimated offset between the reference clock and the simulation
     /// clock.</para>
     /// <para>Positive values mean the simulation clock is behind, and needs to run
     /// slightly faster to catch up. Negative values mean the simulation clock is
     /// ahead, and needs to slow down slightly.</para>
     /// <para>See <see cref="ClockStretchFactor"/> for more clock speed adjustment.</para></summary>
-    public double ClockOffset { get { return (double)_networkTimeGd.Get(PropertyNameGd.ClockOffset); } }
+    public static double ClockOffset { get { return (double)_networkTimeGd.Get(PropertyNameGd.ClockOffset); } }
     /// <summary>The current estimated offset between the reference clock and the remote
     /// clock.
     /// <para>Positive values mean the reference clock is behind the remote clock,
     /// Negative values mean the reference clock is ahead of the remote clock.</para>
     /// <para>Returns the same as <see cref="NetworkTimeSynchronizer.RemoteOffset"/>.</para></summary>
-    public double RemoteClockOffset { get { return (double)_networkTimeGd.Get(PropertyNameGd.RemoteClockOffset); } }
+    public static double RemoteClockOffset { get { return (double)_networkTimeGd.Get(PropertyNameGd.RemoteClockOffset); } }
     #endregion
 
     /// <summary>Internal reference of the NetworkTime GDScript autoload.</summary>
-    GodotObject _networkTimeGd;
+    static GodotObject _networkTimeGd;
 
     /// <summary>Internal constructor used by <see cref="NetfoxSharp"/>. Should not be used elsewhere.</summary>
     /// <param name="networkTimeGd">The NetworkRollback GDScript autoload.</param>
@@ -179,39 +179,39 @@ public partial class NetworkTime : Node
     /// <para>On clients, the initial time sync must complete before any ticks are emitted.</para>
     /// <para>To check if this initial sync is done, see <see cref="IsInitialSyncDone"/>. If
     /// you need a signal, see <see cref="AfterSync"/>.</para></summary>
-    public void Start() { _networkTimeGd.Call(MethodNameGd.Start); }
+    public static void Start() { _networkTimeGd.Call(MethodNameGd.Start); }
     /// <summary><para>Stops NetworkTime.</para>
     /// <para>This will stop the time sync in the background, and no more ticks will be 
     /// emitted until the next start.</para></summary>
-    public void Stop() { _networkTimeGd.Call(MethodNameGd.Stop); }
+    public static void Stop() { _networkTimeGd.Call(MethodNameGd.Stop); }
     /// <summary>Check if the initial time sync is done.</summary>
     /// <returns>Whether the initial sync is done.</returns>
-    public bool IsInitialSyncDone() { return (bool)_networkTimeGd.Call(MethodNameGd.IsInitialSyncDone); }
+    public static bool IsInitialSyncDone() { return (bool)_networkTimeGd.Call(MethodNameGd.IsInitialSyncDone); }
     /// <summary><para>Check if client's time sync is complete.</para>
     /// <para><b>NOTE: </b> Using this from a client is considered an error.</para></summary>
     /// <param name="peerId">The id of the client to check.</param>
     /// <returns>Whether the client's time sync is complete.</returns>
-    public bool IsClientSynced(long peerId) { return (bool)_networkTimeGd.Call(MethodNameGd.IsClientSynced, peerId); }
+    public static bool IsClientSynced(long peerId) { return (bool)_networkTimeGd.Call(MethodNameGd.IsClientSynced, peerId); }
     /// <summary>Converts a duration of ticks to seconds.</summary>
     /// <param name="ticks">The number of ticks to convert.</param>
     /// <returns>The number of seconds the specified ticks represent.</returns>
-    public double TicksToSeconds(long ticks) { return (double)_networkTimeGd.Call(MethodNameGd.TicksToSeconds, ticks); }
+    public static double TicksToSeconds(long ticks) { return (double)_networkTimeGd.Call(MethodNameGd.TicksToSeconds, ticks); }
     /// <summary>Converts a duration of seconds to ticks.</summary>
     /// <param name="ticks">The number of seconds to convert.</param>
     /// <returns>The number of ticks the specified seconds represent.</returns>
-    public long SecondsToTicks(double seconds) { return (long)_networkTimeGd.Call(MethodNameGd.SecondsToTicks, seconds); }
+    public static long SecondsToTicks(double seconds) { return (long)_networkTimeGd.Call(MethodNameGd.SecondsToTicks, seconds); }
     /// <summary>Calculate the duration between two ticks in seconds.</summary>
     /// <param name="fromTick">The tick to start counting from.</param>
     /// <param name="toTick">The tick to count to.</param>
     /// <returns>The difference in seconds between the values. Returns a negative number if
     /// toTick is smaller than fromTick.</returns>
-    public double SecondsBetween(long fromTick, long toTick) { return (double)_networkTimeGd.Call(MethodNameGd.SecondsBetween, fromTick, toTick); }
+    public static double SecondsBetween(long fromTick, long toTick) { return (double)_networkTimeGd.Call(MethodNameGd.SecondsBetween, fromTick, toTick); }
     /// <summary>Calculate the duration between two times in ticks.</summary>
     /// <param name="fromSecond">The second to start counting from.</param>
     /// <param name="toSecond">The second to count to.</param>
     /// <returns>The difference in ticks between the values. Returns a negative number if
     /// toSecond is smaller than fromSecond.</returns>
-    public long TicksBetween(double fromSecond, double toSecond) { return (long)_networkTimeGd.Call(MethodNameGd.TicksBetween, fromSecond, toSecond); }
+    public static long TicksBetween(double fromSecond, double toSecond) { return (long)_networkTimeGd.Call(MethodNameGd.TicksBetween, fromSecond, toSecond); }
     #endregion
 
     #region StringName Constants

--- a/addons/netfox_sharp/autoloads/NetworkTimeSynchronizer.cs
+++ b/addons/netfox_sharp/autoloads/NetworkTimeSynchronizer.cs
@@ -17,34 +17,34 @@ public partial class NetworkTimeSynchronizer : Node
 {
     #region Public Variables
     /// <summary>Time between sync samples, in seconds.</summary>
-    public double SyncInterval { get { return (double)_networkTimeSynchronizerGd.Get(PropertyNameGd.SyncInterval); } }
+    public static double SyncInterval { get { return (double)_networkTimeSynchronizerGd.Get(PropertyNameGd.SyncInterval); } }
     /// <summary>Number of measurements (samples) to use for time synchronization.</summary>
-    public long SyncSamples { get { return (long)_networkTimeSynchronizerGd.Get(PropertyNameGd.SyncSamples); } }
+    public static long SyncSamples { get { return (long)_networkTimeSynchronizerGd.Get(PropertyNameGd.SyncSamples); } }
     /// <summary><para>Number of iterations to nudge towards the host's remote clock.</para>
     /// <para>Lower values result in more aggressive changes in clock and may be more 
     /// sensitive to jitter. Larger values may end up approaching the remote clock
     /// too slowly.</para></summary>
-    public long AdjustSteps { get { return (long)_networkTimeSynchronizerGd.Get(PropertyNameGd.AdjustSteps); } }
+    public static long AdjustSteps { get { return (long)_networkTimeSynchronizerGd.Get(PropertyNameGd.AdjustSteps); } }
     /// <summary><para>Largest tolerated offset from the host's remote clock before panicking.</para>
     /// <para>Once this threshold is reached, the clock will be reset to the remote clock's 
     /// value, and the nudge process will start from scratch.</para></summary>
-    public double PanicThreshold { get { return (double)_networkTimeSynchronizerGd.Get(PropertyNameGd.PanicThreshold); } }
+    public static double PanicThreshold { get { return (double)_networkTimeSynchronizerGd.Get(PropertyNameGd.PanicThreshold); } }
     /// <summary><para>Measured roundtrip time measured to the host.</para>
     /// <para>This value is calculated from multiple samples. The actual roundtrip times 
     /// can be anywhere in the <see cref="Rtt"/> +/- <see cref="RttJitter"/> range.</para></summary>
-    public double Rtt { get { return (double)_networkTimeSynchronizerGd.Get(PropertyNameGd.Rtt); } }
+    public static double Rtt { get { return (double)_networkTimeSynchronizerGd.Get(PropertyNameGd.Rtt); } }
     /// <summary><para>Measured jitter in the roundtrip time to the host remote.</para>
     /// <para>This value is calculated from multiple samples. The actual roundtrip times 
     /// can be anywhere in the <see cref="Rtt"/> +/- <see cref="RttJitter"/> range.</para></summary>
-    public double RttJitter { get { return (double)_networkTimeSynchronizerGd.Get(PropertyNameGd.RttJitter); } }
+    public static double RttJitter { get { return (double)_networkTimeSynchronizerGd.Get(PropertyNameGd.RttJitter); } }
     /// <summary><para>Estimated offset from the host's remote clock.</para>
     /// <para>Positive values mean that the host's remote clock is ahead of ours, while
     /// negative values mean that our clock is behind the host's remote.</para></summary>
-    public double RemoteOffset { get { return (double)_networkTimeSynchronizerGd.Get(PropertyNameGd.RemoteOffset); } }
+    public static double RemoteOffset { get { return (double)_networkTimeSynchronizerGd.Get(PropertyNameGd.RemoteOffset); } }
     #endregion
 
     /// <summary>Internal reference of the NetworkTimeSynchronizer GDScript autoload.</summary>
-    GodotObject _networkTimeSynchronizerGd;
+    static GodotObject _networkTimeSynchronizerGd;
 
     /// <summary>Internal constructor used by <see cref="NetfoxSharp"/>. Should not be used elsewhere.</summary>
     /// <param name="networkTimeGd">The NetworkTimeSynchronizer GDScript autoload.</param>
@@ -75,12 +75,12 @@ public partial class NetworkTimeSynchronizer : Node
 
     #region Methods
     /// <summary><para>Starts the NetworkTimeSynchronizer.</para></summary>
-    public void Start() { _networkTimeSynchronizerGd.Call(MethodNameGd.Start); }
+    public static void Start() { _networkTimeSynchronizerGd.Call(MethodNameGd.Start); }
     /// <summary><para>Stops the NetworkTimeSynchronizer.</para></summary>
-    public void Stop() { _networkTimeSynchronizerGd.Call(MethodNameGd.Stop); }
+    public static void Stop() { _networkTimeSynchronizerGd.Call(MethodNameGd.Stop); }
     /// <summary>Get the current time from the reference clock.</summary>
     /// <returns>The time, in seconds.</returns>
-    public double GetTime() { return (double)_networkTimeSynchronizerGd.Call(MethodNameGd.GetTime); }
+    public static double GetTime() { return (double)_networkTimeSynchronizerGd.Call(MethodNameGd.GetTime); }
     #endregion
 
     #region StringName Constants

--- a/addons/netfox_sharp/plugin.cfg
+++ b/addons/netfox_sharp/plugin.cfg
@@ -3,5 +3,5 @@
 name="NetfoxSharp"
 description=""
 author="CyFur Studios"
-version="0.4.0"
+version="0.5.0"
 script="NetfoxSharpPlugin.cs"


### PR DESCRIPTION
- Added static typing to netfox autoload wrappers.

BREAKING CHANGE: references to `NetfoxSharp.[node]` nodes (IE `NetfoxSharp.NetworkTime`) have `NetfoxSharp.` removed (IE are now called with `NetworkTime`). The exception is signals, which still require the `NetfoxSharp.[node]` instances.